### PR TITLE
Fix iverilog warnings

### DIFF
--- a/rtl/aucohl_lib.v
+++ b/rtl/aucohl_lib.v
@@ -104,7 +104,7 @@ endmodule
 /*
     A glitch filter
 */
-module aucohl_glitch_filter #(parameter N = 8, CLKDIV = 1) (
+module aucohl_glitch_filter #(parameter N = 8, CLKDIV = 8'd1) (
     input   wire    clk,
     input   wire    rst_n,
     input   wire    in,


### PR DESCRIPTION
```
rtl/aucohl_lib.v:118: warning: Port 4 (clk_div) of aucohl_ticker expects 8 bits, got 32.
```